### PR TITLE
Arregla problemas de incompatibilidad con PHP 7 y otros

### DIFF
--- a/qvo_payment_gateway.php
+++ b/qvo_payment_gateway.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package QVO Payment Gateway
- * @version 1.2.1
+ * @version 1.2.2
  * @link              https://qvo.cl
  * @since             1.2.0
  */
@@ -9,7 +9,7 @@
 /**
  * Plugin Name: QVO Payment Gateway
  * Author: QVO
- * Version: 1.2.1
+ * Version: 1.2.2
  * Description: Process payments using QVO API Webpay Plus
  * Author URI: http://qvo.cl/
  * License: GPLv2 or later


### PR DESCRIPTION
Se arreglaron problemas de compatibilidad con PHP 7, se actualizaron funciones deprecadas de Woocommerce, ya que en 3.0 no se permite acceder directamente a la información y se agregó un chequeador para Woocommerce que desactiva el plugin si Woocommerce no está activo